### PR TITLE
fix: prevent a crash when adding a lesson without logged in user

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,6 +17,10 @@ function getProgress(lessons) {
 }
 
 function isLessonComplete(courseId, lessonId, user) {
+  if (!user) {
+    // just browsing the lessons
+    return false
+  }
   const course = user.courses.find(course => course.id === courseId)
   if (course) {
     const lesson = course.lessons.find(lesson => lesson.id === lessonId)


### PR DESCRIPTION
The `user` can be `null` when calling this function

<img width="774" alt="Screen Shot 2022-03-17 at 09 11 03" src="https://user-images.githubusercontent.com/2212006/158816815-862f6dc3-0fc7-45be-8b66-d848a43e04d2.png">

```js
const user = this.store.user.data;
  return createLesson(lesson.response, courseId, user, baseUrl)
} else {
  return createLesson(lesson.response, courseId, null, baseUrl)
}
```